### PR TITLE
透明代理绕过 App（白名单模式）在非命令行启动时无效

### DIFF
--- a/box/scripts/box.tproxy
+++ b/box/scripts/box.tproxy
@@ -33,7 +33,7 @@ find_packages_uid() {
   for user_package in ${user_packages_list[@]} ; do
     user=$(echo ${user_package} | awk -F ':' '{print $1}')
     package=$(echo ${user_package} | awk -F ':' '{print $2}')
-    uid_list[${#uid_list[@]}]=$(expr ${user} \* "100000" + $(cat /data/system/packages.list | grep ${package} | awk '{print $2}'))
+    uid_list[${#uid_list[@]}]=$(expr ${user} \* "100000" + $(awk '{if($1=="'${package}'"){print $2}}' /data/system/packages.list))
   done
 }
 


### PR DESCRIPTION
简单处理下再使用白名单模式的时候，过滤谷歌商店会导致所有从谷歌商店下载app都查找出来的问题