### PR TITLE
Repair application does not exist, resulting in expr Unexpected end o…

### DIFF
--- a/box/scripts/box.tproxy
+++ b/box/scripts/box.tproxy
@@ -33,7 +33,10 @@ find_packages_uid() {
   for user_package in ${user_packages_list[@]} ; do
     user=$(echo ${user_package} | awk -F ':' '{print $1}')
     package=$(echo ${user_package} | awk -F ':' '{print $2}')
-    uid_list[${#uid_list[@]}]=$(expr ${user} \* "100000" + $(awk '{if($1=="'${package}'"){print $2}}' /data/system/packages.list))
+    uid="$(awk '{if($1=="'${package}'"){print $2}}' /data/system/packages.list)"
+    if [[ -n "${uid}" ]]; then
+      uid_list[${#uid_list[@]}]=$(expr ${user} \* "100000" + ${uid})
+    fi
   done
 }
 


### PR DESCRIPTION
## 修复 expr: Unexpected end of input 错误
#31 

## 原因
当 package 为一个不存在的应用时(比如 com.undefined.app)，`$(awk '{if($1=="'${package}'"){print $2}}' /data/system/packages.list)` 返回空值，导致整体解析为`uid_list[0]=$(expr 0 * "100000" + )`(假设用户为 0，uid_list 目前为空)，出现错误

## 修复
将
```bash
 uid_list[${#uid_list[@]}]=$(expr ${user} \* "100000" + $(awk '{if($1=="'${package}'"){print $2}}' /data/system/packages.list))
```
改为
```bash
uid="$(awk '{if($1=="'${package}'"){print $2}}' /data/system/packages.list)"
if [[ -n "${uid}" ]]; then
  uid_list[${#uid_list[@]}]=$(expr ${user} \* "100000" + ${uid})
fi
```